### PR TITLE
feat: add optional base url config to CovalentClient

### DIFF
--- a/covalentclient/covalent_client.go
+++ b/covalentclient/covalent_client.go
@@ -10,6 +10,8 @@ type CovalentClientSettings struct {
 	Debug *bool `json:"debug,omitempty"`
 	//  The number of concurrent requests allowed.
 	ThreadCount *int `json:"thread_count,omitempty"`
+	// The base URL for the Covalent API
+	BaseURL string `json:"base_url,omitempty"`
 }
 
 type CovalentClientType struct {
@@ -31,6 +33,7 @@ func CovalentClient(apiKey string, settings ...CovalentClientSettings) *Covalent
 	client := &CovalentClientType{}
 	validator := utils.NewApiKeyValidator(apiKey)
 	isValidKey := validator.IsValidApiKey()
+	baseURL := "https://api.covalenthq.com"
 
 	if len(settings) == 0 {
 		client.Debug = defaultDebug
@@ -50,15 +53,19 @@ func CovalentClient(apiKey string, settings ...CovalentClientSettings) *Covalent
 		} else {
 			client.ThreadCount = *setting.ThreadCount
 		}
+
+		if setting.BaseURL != "" {
+			baseURL = setting.BaseURL
+		}
 	}
 
-	client.SecurityService = services.NewSecurityServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.BalanceService = services.NewBalanceServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.BaseService = services.NewBaseServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.NftService = services.NewNftServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.PricingService = services.NewPricingServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.TransactionService = services.NewTransactionServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
-	client.XykService = services.NewXykServiceImpl(apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.SecurityService = services.NewSecurityServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.BalanceService = services.NewBalanceServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.BaseService = services.NewBaseServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.NftService = services.NewNftServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.PricingService = services.NewPricingServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.TransactionService = services.NewTransactionServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
+	client.XykService = services.NewXykServiceImpl(baseURL, apiKey, client.Debug, client.ThreadCount, isValidKey)
 
 	return client
 

--- a/services/balance_service.go
+++ b/services/balance_service.go
@@ -481,9 +481,9 @@ type GetNativeTokenBalanceQueryParamOpts struct {
 	BlockHeight *string `json:"blockHeight,omitempty"`
 }
 
-func NewBalanceServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) BalanceService {
+func NewBalanceServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) BalanceService {
 
-	return &balanceServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &balanceServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type BalanceService interface {
@@ -538,6 +538,7 @@ type BalanceService interface {
 }
 
 type balanceServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -546,7 +547,7 @@ type balanceServiceImpl struct {
 
 func (s *balanceServiceImpl) GetTokenBalancesForWalletAddress(chainName chains.Chain, walletAddress string, queryParamOpts ...GetTokenBalancesForWalletAddressQueryParamOpts) (*utils.Response[BalancesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/balances_v2/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/balances_v2/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -657,7 +658,7 @@ func (s *balanceServiceImpl) GetTokenBalancesForWalletAddress(chainName chains.C
 
 func (s *balanceServiceImpl) GetHistoricalPortfolioForWalletAddress(chainName chains.Chain, walletAddress string, queryParamOpts ...GetHistoricalPortfolioForWalletAddressQueryParamOpts) (*utils.Response[PortfolioResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/portfolio_v2/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/portfolio_v2/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -767,7 +768,7 @@ func (s *balanceServiceImpl) GetErc20TransfersForWalletAddress(chainName chains.
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transfers_v2/", chainName, walletAddress)
+		apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transfers_v2/", s.BaseURL, chainName, walletAddress)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -861,7 +862,7 @@ func (s *balanceServiceImpl) GetErc20TransfersForWalletAddress(chainName chains.
 }
 
 func (s *balanceServiceImpl) GetErc20TransfersForWalletAddressByPage(chainName chains.Chain, walletAddress string, queryParamOpts ...GetErc20TransfersForWalletAddressQueryParamOpts) (*utils.Response[Erc20TransfersResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transfers_v2/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transfers_v2/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -987,7 +988,7 @@ func (s *balanceServiceImpl) GetTokenHoldersV2ForTokenAddress(chainName chains.C
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/tokens/%s/token_holders_v2/", chainName, tokenAddress)
+		apiURL := fmt.Sprintf("%s/v1/%v/tokens/%s/token_holders_v2/", s.BaseURL, chainName, tokenAddress)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -1073,7 +1074,7 @@ func (s *balanceServiceImpl) GetTokenHoldersV2ForTokenAddress(chainName chains.C
 }
 
 func (s *balanceServiceImpl) GetTokenHoldersV2ForTokenAddressByPage(chainName chains.Chain, tokenAddress string, queryParamOpts ...GetTokenHoldersV2ForTokenAddressQueryParamOpts) (*utils.Response[TokenHoldersResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/tokens/%s/token_holders_v2/", chainName, tokenAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/tokens/%s/token_holders_v2/", s.BaseURL, chainName, tokenAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1180,7 +1181,7 @@ func (s *balanceServiceImpl) GetTokenHoldersV2ForTokenAddressByPage(chainName ch
 
 func (s *balanceServiceImpl) GetHistoricalTokenBalancesForWalletAddress(chainName chains.Chain, walletAddress string, queryParamOpts ...GetHistoricalTokenBalancesForWalletAddressQueryParamOpts) (*utils.Response[HistoricalBalancesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/historical_balances/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/historical_balances/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1299,7 +1300,7 @@ func (s *balanceServiceImpl) GetHistoricalTokenBalancesForWalletAddress(chainNam
 
 func (s *balanceServiceImpl) GetNativeTokenBalance(chainName chains.Chain, walletAddress string, queryParamOpts ...GetNativeTokenBalanceQueryParamOpts) (*utils.Response[TokenBalanceNativeResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/balances_native/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/balances_native/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/base_service.go
+++ b/services/base_service.go
@@ -352,9 +352,9 @@ type GetGasPricesQueryParamOpts struct {
 	QuoteCurrency *quotes.Quote `json:"quoteCurrency,omitempty"`
 }
 
-func NewBaseServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) BaseService {
+func NewBaseServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) BaseService {
 
-	return &baseServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &baseServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type BaseService interface {
@@ -437,6 +437,7 @@ type BaseService interface {
 }
 
 type baseServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -445,7 +446,7 @@ type baseServiceImpl struct {
 
 func (s *baseServiceImpl) GetBlock(chainName chains.Chain, blockHeight string) (*utils.Response[BlockResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block_v2/%s/", chainName, blockHeight)
+	apiURL := fmt.Sprintf("%s/v1/%v/block_v2/%s/", s.BaseURL, chainName, blockHeight)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -532,7 +533,7 @@ func (s *baseServiceImpl) GetBlock(chainName chains.Chain, blockHeight string) (
 
 func (s *baseServiceImpl) GetResolvedAddress(chainName chains.Chain, walletAddress string) (*utils.Response[ResolvedAddress], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/resolve_address/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/resolve_address/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -630,7 +631,7 @@ func (s *baseServiceImpl) GetBlockHeights(chainName chains.Chain, startDate stri
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block_v2/%s/%s/", chainName, startDate, endDate)
+		apiURL := fmt.Sprintf("%s/v1/%v/block_v2/%s/%s/", s.BaseURL, chainName, startDate, endDate)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -708,7 +709,7 @@ func (s *baseServiceImpl) GetBlockHeights(chainName chains.Chain, startDate stri
 }
 
 func (s *baseServiceImpl) GetBlockHeightsByPage(chainName chains.Chain, startDate string, endDate string, queryParamOpts ...GetBlockHeightsQueryParamOpts) (*utils.Response[BlockHeightsResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block_v2/%s/%s/", chainName, startDate, endDate)
+	apiURL := fmt.Sprintf("%s/v1/%v/block_v2/%s/%s/", s.BaseURL, chainName, startDate, endDate)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -807,7 +808,7 @@ func (s *baseServiceImpl) GetBlockHeightsByPage(chainName chains.Chain, startDat
 
 func (s *baseServiceImpl) GetLogs(chainName chains.Chain, queryParamOpts ...GetLogsQueryParamOpts) (*utils.Response[GetLogsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/events/", chainName)
+	apiURL := fmt.Sprintf("%s/v1/%v/events/", s.BaseURL, chainName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -933,7 +934,7 @@ func (s *baseServiceImpl) GetLogEventsByAddress(chainName chains.Chain, contract
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/events/address/%s/", chainName, contractAddress)
+		apiURL := fmt.Sprintf("%s/v1/%v/events/address/%s/", s.BaseURL, chainName, contractAddress)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -1019,7 +1020,7 @@ func (s *baseServiceImpl) GetLogEventsByAddress(chainName chains.Chain, contract
 }
 
 func (s *baseServiceImpl) GetLogEventsByAddressByPage(chainName chains.Chain, contractAddress string, queryParamOpts ...GetLogEventsByAddressQueryParamOpts) (*utils.Response[LogEventsByAddressResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/events/address/%s/", chainName, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/events/address/%s/", s.BaseURL, chainName, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1137,7 +1138,7 @@ func (s *baseServiceImpl) GetLogEventsByTopicHash(chainName chains.Chain, topicH
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/events/topics/%s/", chainName, topicHash)
+		apiURL := fmt.Sprintf("%s/v1/%v/events/topics/%s/", s.BaseURL, chainName, topicHash)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -1227,7 +1228,7 @@ func (s *baseServiceImpl) GetLogEventsByTopicHash(chainName chains.Chain, topicH
 }
 
 func (s *baseServiceImpl) GetLogEventsByTopicHashByPage(chainName chains.Chain, topicHash string, queryParamOpts ...GetLogEventsByTopicHashQueryParamOpts) (*utils.Response[LogEventsByTopicHashResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/events/topics/%s/", chainName, topicHash)
+	apiURL := fmt.Sprintf("%s/v1/%v/events/topics/%s/", s.BaseURL, chainName, topicHash)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1338,7 +1339,7 @@ func (s *baseServiceImpl) GetLogEventsByTopicHashByPage(chainName chains.Chain, 
 
 func (s *baseServiceImpl) GetAllChains() (*utils.Response[AllChainsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/chains/")
+	apiURL := fmt.Sprintf("%s/v1/chains/", s.BaseURL)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1425,7 +1426,7 @@ func (s *baseServiceImpl) GetAllChains() (*utils.Response[AllChainsResponse], er
 
 func (s *baseServiceImpl) GetAllChainStatus() (*utils.Response[AllChainsStatusResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/chains/status/")
+	apiURL := fmt.Sprintf("%s/v1/chains/status/", s.BaseURL)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1512,7 +1513,7 @@ func (s *baseServiceImpl) GetAllChainStatus() (*utils.Response[AllChainsStatusRe
 
 func (s *baseServiceImpl) GetAddressActivity(walletAddress string, queryParamOpts ...GetAddressActivityQueryParamOpts) (*utils.Response[ChainActivityResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/address/%s/activity/", walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/address/%s/activity/", s.BaseURL, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1607,7 +1608,7 @@ func (s *baseServiceImpl) GetAddressActivity(walletAddress string, queryParamOpt
 
 func (s *baseServiceImpl) GetGasPrices(chainName chains.Chain, eventType string, queryParamOpts ...GetGasPricesQueryParamOpts) (*utils.Response[GasPricesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/event/%s/gas_prices/", chainName, eventType)
+	apiURL := fmt.Sprintf("%s/v1/%v/event/%s/gas_prices/", s.BaseURL, chainName, eventType)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/nft_service.go
+++ b/services/nft_service.go
@@ -421,9 +421,9 @@ type GetNftMarketFloorPriceQueryParamOpts struct {
 	QuoteCurrency *quotes.Quote `json:"quoteCurrency,omitempty"`
 }
 
-func NewNftServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) NftService {
+func NewNftServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) NftService {
 
-	return &nftServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &nftServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type NftService interface {
@@ -524,6 +524,7 @@ type NftService interface {
 }
 
 type nftServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -543,7 +544,7 @@ func (s *nftServiceImpl) GetChainCollections(chainName chains.Chain, queryParamO
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/collections/", chainName)
+		apiURL := fmt.Sprintf("%s/v1/%v/nft/collections/", s.BaseURL, chainName)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -625,7 +626,7 @@ func (s *nftServiceImpl) GetChainCollections(chainName chains.Chain, queryParamO
 }
 
 func (s *nftServiceImpl) GetChainCollectionsByPage(chainName chains.Chain, queryParamOpts ...GetChainCollectionsQueryParamOpts) (*utils.Response[ChainCollectionResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/collections/", chainName)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/collections/", s.BaseURL, chainName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -728,7 +729,7 @@ func (s *nftServiceImpl) GetChainCollectionsByPage(chainName chains.Chain, query
 
 func (s *nftServiceImpl) GetNftsForAddress(chainName chains.Chain, walletAddress string, queryParamOpts ...GetNftsForAddressQueryParamOpts) (*utils.Response[NftAddressBalanceNftResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/balances_nft/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/balances_nft/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -842,7 +843,7 @@ func (s *nftServiceImpl) GetTokenIdsForContractWithMetadata(chainName chains.Cha
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/metadata/", chainName, contractAddress)
+		apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/metadata/", s.BaseURL, chainName, contractAddress)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -936,7 +937,7 @@ func (s *nftServiceImpl) GetTokenIdsForContractWithMetadata(chainName chains.Cha
 }
 
 func (s *nftServiceImpl) GetTokenIdsForContractWithMetadataByPage(chainName chains.Chain, contractAddress string, queryParamOpts ...GetTokenIdsForContractWithMetadataQueryParamOpts) (*utils.Response[NftMetadataResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/metadata/", chainName, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/metadata/", s.BaseURL, chainName, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1051,7 +1052,7 @@ func (s *nftServiceImpl) GetTokenIdsForContractWithMetadataByPage(chainName chai
 
 func (s *nftServiceImpl) GetNftMetadataForGivenTokenIdForContract(chainName chains.Chain, contractAddress string, tokenId string, queryParamOpts ...GetNftMetadataForGivenTokenIdForContractQueryParamOpts) (*utils.Response[NftMetadataResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/metadata/%s/", chainName, contractAddress, tokenId)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/metadata/%s/", s.BaseURL, chainName, contractAddress, tokenId)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1150,7 +1151,7 @@ func (s *nftServiceImpl) GetNftMetadataForGivenTokenIdForContract(chainName chai
 
 func (s *nftServiceImpl) GetNftTransactionsForContractTokenId(chainName chains.Chain, contractAddress string, tokenId string, queryParamOpts ...GetNftTransactionsForContractTokenIdQueryParamOpts) (*utils.Response[NftTransactionsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/tokens/%s/nft_transactions/%s/", chainName, contractAddress, tokenId)
+	apiURL := fmt.Sprintf("%s/v1/%v/tokens/%s/nft_transactions/%s/", s.BaseURL, chainName, contractAddress, tokenId)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1245,7 +1246,7 @@ func (s *nftServiceImpl) GetNftTransactionsForContractTokenId(chainName chains.C
 
 func (s *nftServiceImpl) GetTraitsForCollection(chainName chains.Chain, collectionContract string) (*utils.Response[NftCollectionTraitsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/traits/", chainName, collectionContract)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/traits/", s.BaseURL, chainName, collectionContract)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1332,7 +1333,7 @@ func (s *nftServiceImpl) GetTraitsForCollection(chainName chains.Chain, collecti
 
 func (s *nftServiceImpl) GetAttributesForTraitInCollection(chainName chains.Chain, collectionContract string, trait string) (*utils.Response[NftCollectionAttributesForTraitResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/traits/%s/attributes/", chainName, collectionContract, trait)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/traits/%s/attributes/", s.BaseURL, chainName, collectionContract, trait)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1419,7 +1420,7 @@ func (s *nftServiceImpl) GetAttributesForTraitInCollection(chainName chains.Chai
 
 func (s *nftServiceImpl) GetCollectionTraitsSummary(chainName chains.Chain, collectionContract string) (*utils.Response[NftCollectionTraitSummaryResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/%s/traits_summary/", chainName, collectionContract)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/%s/traits_summary/", s.BaseURL, chainName, collectionContract)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1506,7 +1507,7 @@ func (s *nftServiceImpl) GetCollectionTraitsSummary(chainName chains.Chain, coll
 
 func (s *nftServiceImpl) CheckOwnershipInNft(chainName chains.Chain, walletAddress string, collectionContract string, queryParamOpts ...CheckOwnershipInNftQueryParamOpts) (*utils.Response[NftOwnershipForCollectionResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/collection/%s/", chainName, walletAddress, collectionContract)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/collection/%s/", s.BaseURL, chainName, walletAddress, collectionContract)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1605,7 +1606,7 @@ func (s *nftServiceImpl) CheckOwnershipInNft(chainName chains.Chain, walletAddre
 
 func (s *nftServiceImpl) CheckOwnershipInNftForSpecificTokenId(chainName chains.Chain, walletAddress string, collectionContract string, tokenId string) (*utils.Response[NftOwnershipForCollectionResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/collection/%s/token/%s/", chainName, walletAddress, collectionContract, tokenId)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/collection/%s/token/%s/", s.BaseURL, chainName, walletAddress, collectionContract, tokenId)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1692,7 +1693,7 @@ func (s *nftServiceImpl) CheckOwnershipInNftForSpecificTokenId(chainName chains.
 
 func (s *nftServiceImpl) GetNftMarketSaleCount(chainName chains.Chain, contractAddress string, queryParamOpts ...GetNftMarketSaleCountQueryParamOpts) (*utils.Response[NftMarketSaleCountResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft_market/%s/sale_count/", chainName, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft_market/%s/sale_count/", s.BaseURL, chainName, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1791,7 +1792,7 @@ func (s *nftServiceImpl) GetNftMarketSaleCount(chainName chains.Chain, contractA
 
 func (s *nftServiceImpl) GetNftMarketVolume(chainName chains.Chain, contractAddress string, queryParamOpts ...GetNftMarketVolumeQueryParamOpts) (*utils.Response[NftMarketVolumeResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft_market/%s/volume/", chainName, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft_market/%s/volume/", s.BaseURL, chainName, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1890,7 +1891,7 @@ func (s *nftServiceImpl) GetNftMarketVolume(chainName chains.Chain, contractAddr
 
 func (s *nftServiceImpl) GetNftMarketFloorPrice(chainName chains.Chain, contractAddress string, queryParamOpts ...GetNftMarketFloorPriceQueryParamOpts) (*utils.Response[NftMarketFloorPriceResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft_market/%s/floor_price/", chainName, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft_market/%s/floor_price/", s.BaseURL, chainName, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/pricing_service.go
+++ b/services/pricing_service.go
@@ -91,9 +91,9 @@ type Response[T any] struct {
 	ErrorMessage *string `json:"error_message"`
 }
 
-func NewPricingServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) PricingService {
+func NewPricingServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) PricingService {
 
-	return &pricingServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &pricingServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type PricingService interface {
@@ -107,6 +107,7 @@ type PricingService interface {
 }
 
 type pricingServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -115,7 +116,7 @@ type pricingServiceImpl struct {
 
 func (s *pricingServiceImpl) GetTokenPrices(chainName chains.Chain, quoteCurrency quotes.Quote, contractAddress string, queryParamOpts ...GetTokenPricesQueryParamOpts) (*Response[TokenPricesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/pricing/historical_by_addresses_v2/%v/%v/%s/", chainName, quoteCurrency, contractAddress)
+	apiURL := fmt.Sprintf("%s/v1/pricing/historical_by_addresses_v2/%v/%v/%s/", s.BaseURL, chainName, quoteCurrency, contractAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/security_service.go
+++ b/services/security_service.go
@@ -133,9 +133,9 @@ type NftApprovalSpender struct {
 	Allowance *string `json:"allowance,omitempty"`
 }
 
-func NewSecurityServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) SecurityService {
+func NewSecurityServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) SecurityService {
 
-	return &securityServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &securityServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type SecurityService interface {
@@ -154,6 +154,7 @@ type SecurityService interface {
 }
 
 type securityServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -162,7 +163,7 @@ type securityServiceImpl struct {
 
 func (s *securityServiceImpl) GetApprovals(chainName chains.Chain, walletAddress string) (*utils.Response[ApprovalsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/approvals/%s/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/approvals/%s/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -249,7 +250,7 @@ func (s *securityServiceImpl) GetApprovals(chainName chains.Chain, walletAddress
 
 func (s *securityServiceImpl) GetNftApprovals(chainName chains.Chain, walletAddress string) (*utils.Response[NftApprovalsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/nft/approvals/%s/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/nft/approvals/%s/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/transaction_service.go
+++ b/services/transaction_service.go
@@ -1182,14 +1182,14 @@ type GetTransactionSummaryQueryParamOpts struct {
 	WithGas *bool `json:"withGas,omitempty"`
 }
 
-func NewTransactionServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) TransactionService {
+func NewTransactionServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) TransactionService {
 
 	clientKey = apiKey
 	debugOutput = debug
 	workerCount = threadCount
 	isKeyValid = isValidKey
 
-	return &transactionServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &transactionServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type TransactionService interface {
@@ -1253,6 +1253,7 @@ type TransactionService interface {
 }
 
 type transactionServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -1261,7 +1262,7 @@ type transactionServiceImpl struct {
 
 func (s *transactionServiceImpl) GetTransaction(chainName chains.Chain, txHash string, queryParamOpts ...GetTransactionQueryParamOpts) (*utils.Response[TransactionResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/transaction_v2/%s/", chainName, txHash)
+	apiURL := fmt.Sprintf("%s/v1/%v/transaction_v2/%s/", s.BaseURL, chainName, txHash)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1387,7 +1388,7 @@ func (s *transactionServiceImpl) GetAllTransactionsForAddress(chainName chains.C
 			return
 		}
 
-		apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transactions_v3/", chainName, walletAddress)
+		apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transactions_v3/", s.BaseURL, chainName, walletAddress)
 
 		// Parse the formatted URL
 		parsedURL, err := url.Parse(apiURL)
@@ -1466,7 +1467,7 @@ func (s *transactionServiceImpl) GetAllTransactionsForAddress(chainName chains.C
 }
 
 func (s *transactionServiceImpl) GetAllTransactionsForAddressByPage(chainName chains.Chain, walletAddress string, queryParamOpts ...GetAllTransactionsForAddressQueryParamOpts) (*utils.Response[RecentTransactionsResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transactions_v3/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transactions_v3/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1572,7 +1573,7 @@ func (s *transactionServiceImpl) GetAllTransactionsForAddressByPage(chainName ch
 }
 
 func (s *transactionServiceImpl) GetTransactionsForAddressV3(chainName chains.Chain, walletAddress string, page int, queryParamOpts ...GetTransactionsForAddressV3QueryParamOpts) (*utils.Response[TransactionsResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transactions_v3/page/%d/", chainName, walletAddress, page)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transactions_v3/page/%d/", s.BaseURL, chainName, walletAddress, page)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1678,7 +1679,7 @@ func (s *transactionServiceImpl) GetTransactionsForAddressV3(chainName chains.Ch
 }
 
 func (s *transactionServiceImpl) GetTimeBucketTransactionsForAddress(chainName chains.Chain, walletAddress string, timeBucket int, queryParamOpts ...GetTimeBucketTransactionsForAddressQueryParamOpts) (*utils.Response[TransactionsTimeBucketResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/bulk/transactions/%s/%d/", chainName, walletAddress, timeBucket)
+	apiURL := fmt.Sprintf("%s/v1/%v/bulk/transactions/%s/%d/", s.BaseURL, chainName, walletAddress, timeBucket)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1781,7 +1782,7 @@ func (s *transactionServiceImpl) GetTimeBucketTransactionsForAddress(chainName c
 
 func (s *transactionServiceImpl) GetTransactionsForBlock(chainName chains.Chain, blockHeight string, queryParamOpts ...GetTransactionsForBlockQueryParamOpts) (*utils.Response[TransactionsBlockResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block/%s/transactions_v3/", chainName, blockHeight)
+	apiURL := fmt.Sprintf("%s/v1/%v/block/%s/transactions_v3/", s.BaseURL, chainName, blockHeight)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1883,7 +1884,7 @@ func (s *transactionServiceImpl) GetTransactionsForBlock(chainName chains.Chain,
 }
 
 func (s *transactionServiceImpl) GetTransactionsForBlockHashByPage(chainName chains.Chain, blockHash string, page int, queryParamOpts ...GetTransactionsForBlockHashByPageQueryParamOpts) (*utils.Response[TransactionsBlockPageResponse], error) {
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block_hash/%s/transactions_v3/page/%d/", chainName, blockHash, page)
+	apiURL := fmt.Sprintf("%s/v1/%v/block_hash/%s/transactions_v3/page/%d/", s.BaseURL, chainName, blockHash, page)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1986,7 +1987,7 @@ func (s *transactionServiceImpl) GetTransactionsForBlockHashByPage(chainName cha
 
 func (s *transactionServiceImpl) GetTransactionsForBlockHash(chainName chains.Chain, blockHash string, queryParamOpts ...GetTransactionsForBlockHashQueryParamOpts) (*utils.Response[TransactionsBlockResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/block_hash/%s/transactions_v3/", chainName, blockHash)
+	apiURL := fmt.Sprintf("%s/v1/%v/block_hash/%s/transactions_v3/", s.BaseURL, chainName, blockHash)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -2089,7 +2090,7 @@ func (s *transactionServiceImpl) GetTransactionsForBlockHash(chainName chains.Ch
 
 func (s *transactionServiceImpl) GetTransactionSummary(chainName chains.Chain, walletAddress string, queryParamOpts ...GetTransactionSummaryQueryParamOpts) (*utils.Response[TransactionsSummaryResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/address/%s/transactions_summary/", chainName, walletAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/address/%s/transactions_summary/", s.BaseURL, chainName, walletAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401

--- a/services/xyk_service.go
+++ b/services/xyk_service.go
@@ -764,9 +764,9 @@ type GetTransactionsForDexQueryParamOpts struct {
 	PageNumber *int `json:"pageNumber,omitempty"`
 }
 
-func NewXykServiceImpl(apiKey string, debug bool, threadCount int, isValidKey bool) XykService {
+func NewXykServiceImpl(baseURL string, apiKey string, debug bool, threadCount int, isValidKey bool) XykService {
 
-	return &xykServiceImpl{APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
+	return &xykServiceImpl{BaseURL: baseURL, APIKey: apiKey, Debug: debug, ThreadCount: threadCount, IskeyValid: isValidKey}
 }
 
 type XykService interface {
@@ -877,6 +877,7 @@ type XykService interface {
 }
 
 type xykServiceImpl struct {
+	BaseURL     string
 	APIKey      string
 	Debug       bool
 	ThreadCount int
@@ -885,7 +886,7 @@ type xykServiceImpl struct {
 
 func (s *xykServiceImpl) GetPools(chainName chains.Chain, dexName string, queryParamOpts ...GetPoolsQueryParamOpts) (*utils.Response[PoolResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/pools/", chainName, dexName)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/pools/", s.BaseURL, chainName, dexName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -988,7 +989,7 @@ func (s *xykServiceImpl) GetPools(chainName chains.Chain, dexName string, queryP
 
 func (s *xykServiceImpl) GetDexForPoolAddress(chainName chains.Chain, poolAddress string) (*utils.Response[PoolToDexResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/address/%s/dex_name/", chainName, poolAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/address/%s/dex_name/", s.BaseURL, chainName, poolAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1075,7 +1076,7 @@ func (s *xykServiceImpl) GetDexForPoolAddress(chainName chains.Chain, poolAddres
 
 func (s *xykServiceImpl) GetPoolByAddress(chainName chains.Chain, dexName string, poolAddress string) (*utils.Response[PoolByAddressResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/pools/address/%s/", chainName, dexName, poolAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/pools/address/%s/", s.BaseURL, chainName, dexName, poolAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1162,7 +1163,7 @@ func (s *xykServiceImpl) GetPoolByAddress(chainName chains.Chain, dexName string
 
 func (s *xykServiceImpl) GetPoolsForTokenAddress(chainName chains.Chain, tokenAddress string, page int, queryParamOpts ...GetPoolsForTokenAddressQueryParamOpts) (*utils.Response[PoolsDexDataResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/tokens/address/%s/pools/page/%d/", chainName, tokenAddress, page)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/tokens/address/%s/pools/page/%d/", s.BaseURL, chainName, tokenAddress, page)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1265,7 +1266,7 @@ func (s *xykServiceImpl) GetPoolsForTokenAddress(chainName chains.Chain, tokenAd
 
 func (s *xykServiceImpl) GetAddressExchangeBalances(chainName chains.Chain, dexName string, accountAddress string) (*utils.Response[AddressExchangeBalancesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/address/%s/balances/", chainName, dexName, accountAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/address/%s/balances/", s.BaseURL, chainName, dexName, accountAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1352,7 +1353,7 @@ func (s *xykServiceImpl) GetAddressExchangeBalances(chainName chains.Chain, dexN
 
 func (s *xykServiceImpl) GetPoolsForWalletAddress(chainName chains.Chain, walletAddress string, page int, queryParamOpts ...GetPoolsForWalletAddressQueryParamOpts) (*utils.Response[PoolsDexDataResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/address/%s/pools/page/%d/", chainName, walletAddress, page)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/address/%s/pools/page/%d/", s.BaseURL, chainName, walletAddress, page)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1459,7 +1460,7 @@ func (s *xykServiceImpl) GetPoolsForWalletAddress(chainName chains.Chain, wallet
 
 func (s *xykServiceImpl) GetNetworkExchangeTokens(chainName chains.Chain, dexName string, queryParamOpts ...GetNetworkExchangeTokensQueryParamOpts) (*utils.Response[NetworkExchangeTokensResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/tokens/", chainName, dexName)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/tokens/", s.BaseURL, chainName, dexName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1558,7 +1559,7 @@ func (s *xykServiceImpl) GetNetworkExchangeTokens(chainName chains.Chain, dexNam
 
 func (s *xykServiceImpl) GetLpTokenView(chainName chains.Chain, dexName string, tokenAddress string, queryParamOpts ...GetLpTokenViewQueryParamOpts) (*utils.Response[NetworkExchangeTokenViewResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/tokens/address/%s/view/", chainName, dexName, tokenAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/tokens/address/%s/view/", s.BaseURL, chainName, dexName, tokenAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1653,7 +1654,7 @@ func (s *xykServiceImpl) GetLpTokenView(chainName chains.Chain, dexName string, 
 
 func (s *xykServiceImpl) GetSupportedDEXes() (*utils.Response[SupportedDexesResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/xy=k/supported_dexes/")
+	apiURL := fmt.Sprintf("%s/v1/xy=k/supported_dexes/", s.BaseURL)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1740,7 +1741,7 @@ func (s *xykServiceImpl) GetSupportedDEXes() (*utils.Response[SupportedDexesResp
 
 func (s *xykServiceImpl) GetSingleNetworkExchangeToken(chainName chains.Chain, dexName string, tokenAddress string, queryParamOpts ...GetSingleNetworkExchangeTokenQueryParamOpts) (*utils.Response[SingleNetworkExchangeTokenResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/tokens/address/%s/", chainName, dexName, tokenAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/tokens/address/%s/", s.BaseURL, chainName, dexName, tokenAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1839,7 +1840,7 @@ func (s *xykServiceImpl) GetSingleNetworkExchangeToken(chainName chains.Chain, d
 
 func (s *xykServiceImpl) GetTransactionsForAccountAddress(chainName chains.Chain, dexName string, accountAddress string) (*utils.Response[TransactionsForAccountAddressResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/address/%s/transactions/", chainName, dexName, accountAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/address/%s/transactions/", s.BaseURL, chainName, dexName, accountAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -1926,7 +1927,7 @@ func (s *xykServiceImpl) GetTransactionsForAccountAddress(chainName chains.Chain
 
 func (s *xykServiceImpl) GetTransactionsForTokenAddress(chainName chains.Chain, dexName string, tokenAddress string, queryParamOpts ...GetTransactionsForTokenAddressQueryParamOpts) (*utils.Response[TransactionsForTokenAddressResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/tokens/address/%s/transactions/", chainName, dexName, tokenAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/tokens/address/%s/transactions/", s.BaseURL, chainName, dexName, tokenAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -2025,7 +2026,7 @@ func (s *xykServiceImpl) GetTransactionsForTokenAddress(chainName chains.Chain, 
 
 func (s *xykServiceImpl) GetTransactionsForExchange(chainName chains.Chain, dexName string, poolAddress string, queryParamOpts ...GetTransactionsForExchangeQueryParamOpts) (*utils.Response[TransactionsForExchangeResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/pools/address/%s/transactions/", chainName, dexName, poolAddress)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/pools/address/%s/transactions/", s.BaseURL, chainName, dexName, poolAddress)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -2124,7 +2125,7 @@ func (s *xykServiceImpl) GetTransactionsForExchange(chainName chains.Chain, dexN
 
 func (s *xykServiceImpl) GetTransactionsForDex(chainName chains.Chain, dexName string, queryParamOpts ...GetTransactionsForDexQueryParamOpts) (*utils.Response[NetworkTransactionsResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/transactions/", chainName, dexName)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/transactions/", s.BaseURL, chainName, dexName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -2227,7 +2228,7 @@ func (s *xykServiceImpl) GetTransactionsForDex(chainName chains.Chain, dexName s
 
 func (s *xykServiceImpl) GetEcosystemChartData(chainName chains.Chain, dexName string) (*utils.Response[EcosystemChartDataResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/ecosystem/", chainName, dexName)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/ecosystem/", s.BaseURL, chainName, dexName)
 
 	if !s.IskeyValid {
 		errorCode := 401
@@ -2314,7 +2315,7 @@ func (s *xykServiceImpl) GetEcosystemChartData(chainName chains.Chain, dexName s
 
 func (s *xykServiceImpl) GetHealthData(chainName chains.Chain, dexName string) (*utils.Response[HealthDataResponse], error) {
 
-	apiURL := fmt.Sprintf("https://api.covalenthq.com/v1/%v/xy=k/%s/health/", chainName, dexName)
+	apiURL := fmt.Sprintf("%s/v1/%v/xy=k/%s/health/", s.BaseURL, chainName, dexName)
 
 	if !s.IskeyValid {
 		errorCode := 401


### PR DESCRIPTION
This PR adds an optional `BaseURL` param to the `CovalentClientSettings`, which allows the SDK to use custom API servers, not just the default `https://api.covalenthq.com`.
This feature would be helpful to us because we wrote a mock covalent API server that generates random data for some of our tests, and we would like to use that mock api with the go SDK.